### PR TITLE
Add Node.js requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "nodemailer": "^4.0.1",
     "swagpi": "^0.1.1",
     "vorpal": "^1.12.0"
+  },
+  "engines" : { 
+    "node" : ">=7.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,10 @@ Mailit uses express. The file ./middleware.js at the root of the directory expos
 
  - I'll probably add more functionality later. This is what I need right now.
 
+## Requirements
+
+ - Node.js 7+
+
 ## License
 
 MIT


### PR DESCRIPTION
In order to this change throw an error on machine that doesn't have appropriate Node.js installed, user need to have appropriate configuration of `npm`:

`npm config set engine-strict true`

This is feature of `npm` itself